### PR TITLE
Add an Ajax request to get the spider index url

### DIFF
--- a/SpiderKeeper/app/spider/controller.py
+++ b/SpiderKeeper/app/spider/controller.py
@@ -15,7 +15,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 
-from SpiderKeeper.app import db, agent, app
+from SpiderKeeper.app import db, agent, app, config
 from SpiderKeeper.app.spider.model import JobInstance, Project, JobExecution, SpiderInstance, JobRunType
 
 api_spider_bp = Blueprint('spider', __name__)
@@ -248,7 +248,11 @@ def project_manage():
 
 @app.route("/project/<project_id>/job/dashboard")
 def job_dashboard(project_id):
-    return render_template("job_dashboard.html", job_status=JobExecution.list_jobs(project_id))
+    return render_template(
+        "job_dashboard.html",
+        job_status=JobExecution.list_jobs(project_id),
+        scrapyd_url=config.SERVERS[0],
+    )
 
 
 @app.route("/job/<job_execution_id>/detail")

--- a/SpiderKeeper/app/templates/job_dashboard.html
+++ b/SpiderKeeper/app/templates/job_dashboard.html
@@ -269,3 +269,48 @@
 </div>
 <!-- /.modal -->
 {% endblock %}
+{% block script %}
+<script>
+    $(document).ready(function() {
+        const selectSpiderElement = document.getElementsByName("spider_name")[0];
+        const spiderArgumentsInput = document.getElementsByName("spider_arguments")[0];
+
+        // When the modal is open, try to get the `index_url`
+        // for the spider that is set by default in this modal.
+        $("#job-run-modal").on("shown.bs.modal", function () {
+            setSpiderIndexUrl(selectSpiderElement.value);
+        });
+
+        // When we choose a spider, try to get the `index_url` for this spider.
+        selectSpiderElement.addEventListener("change", (event) => {
+            setSpiderIndexUrl(event.target.value);
+        });
+
+        function setSpiderIndexUrl(spiderName) {
+            $.ajax({
+                url: "{{ scrapyd_url }}/getindexurl.json",
+                method: "get",
+                data: {
+                    project: "{{ project.project_name }}",
+                    spider: spiderName,
+                },
+                dataType: "json",
+                success: function(data) {
+                    var indexUrl = "";
+                    if (typeof data == "object" && data !== null) {
+                        indexUrl = data.index_url
+                    }
+                    if (indexUrl && indexUrl !== "") {
+                        spiderArgumentsInput.value = "index_url=" + indexUrl;
+                    } else {
+                        spiderArgumentsInput.value = "";
+                    }
+                },
+                error: function() {
+                    spiderArgumentsInput.value = "";
+                }
+            });
+        }
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
If the `scrapyd` server has such an endpoint, then when selecting a spider, we get its `index_url` in the arguments field:

<img width="2504" height="1358" alt="image" src="https://github.com/user-attachments/assets/47855380-ace9-48c1-8d4a-bda6e99a4cd5" />
