### PR TITLE
Fix KeyError on spiders key in grabbers response, US-23034

### DIFF
--- a/SpiderKeeper/app/proxy/contrib/scrapy.py
+++ b/SpiderKeeper/app/proxy/contrib/scrapy.py
@@ -62,7 +62,7 @@ class ScrapydProxy(SpiderServiceProxy):
         )
         result = []
         if data and data["status"] == "ok":
-            for spider in data["spiders"]:
+            for spider in data["grabbers"]:
                 spider_instance = SpiderInstance()
                 spider_instance.spider_name = spider["name"]
                 arguments_list = []


### PR DESCRIPTION
## Summary

scrapyd api response:
<img width="1985" height="507" alt="image" src="https://github.com/user-attachments/assets/1b9da48f-3d0b-4470-8a7b-0c66e0c98596" />

spiderkeeper pod errors
<img width="2467" height="360" alt="image" src="https://github.com/user-attachments/assets/acf980d7-abe0-42bb-878c-7f08afb3cb9f" />


- `sync_spiders` scheduler job has been crashing every 10s with `KeyError: 'spiders'` in production (`spiderkeeper-649678bf6c-mjf99`).
- Root cause: commit 6b9918f renamed the scrapyd endpoint URL `list_spiders_with_arguments.json` → `list_grabbers_with_arguments.json` to align with the scrapyd-fork rename, but the response parser on line 65 still read the old `data["spiders"]` key. The new endpoint returns `{"status": "ok", "grabbers": [...]}`.
- One-line fix: `data["spiders"]` → `data["grabbers"]`.

Verified the response shape against the live scrapyd in usummit-prod-eks:
```
$ curl -s 'http://scrapyd:6800/list_grabbers_with_arguments.json?project=grabbers' | jq 'keys'
# ["grabbers", "status", ...]
# items: {"name": "...", "arguments": [{"name": "...", "default_value": "..."}]}
```
The inner loop already iterates `spider["name"]` and `spider["arguments"]`, so no other changes were needed.

## Test plan
- [x] Deploy to staging and confirm `sync_spiders` no longer raises in spiderkeeper logs
- [x] Confirm the SpiderKeeper UI lists grabbers under the `grabbers` project after the next sync interval
- [x] Confirm scheduled jobs continue to launch correctly (uses `arguments_string` populated by this code path)
